### PR TITLE
Clean-up Regex Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Send the following command to a running Errbot instance:
 To query any HTTP status code:
 `!http 200`
 
-By default, regex matching is also active, so any occurrence of `'http?(\s*)\d{3}'` in conversation will get a bot response as well.
+By default, regex matching is also active, so any occurrence of `'http\s*(\d{3})'` in conversation will get a bot response as well.

--- a/httpcats.py
+++ b/httpcats.py
@@ -33,9 +33,9 @@ class HttpCats(BotPlugin):
         else:
             return 'Not a valid HTTP status code ({0})'.format(code)
 
-    @re_botcmd(pattern='http?(\s*)\d{3}', prefixed=False, flags=re.IGNORECASE)
+    @re_botcmd(pattern=r'http\s*(\d{3})', prefixed=False, flags=re.IGNORECASE)
     def re_http(self, message, match):
         """Will show the HTTP status cat for any valid code mentioned in chat"""
-        code = match.group()[-3:]
+        code = match.group(1)
         self.log.debug('Got HTTP code: {0}'.format(code))
         return self.http(message, [code])


### PR DESCRIPTION
Use regex groups to match the code to look up.
Use raw string to avoid deprecation warnings.
Update regex in README.