### PR TITLE
Test Using Mocks

### DIFF
--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -1,2 +1,3 @@
-pytest
 errbot
+pytest
+unittest.mock

--- a/test_httpcats.py
+++ b/test_httpcats.py
@@ -1,6 +1,7 @@
-import os
-import httpcats
 from errbot.backends.test import testbot
+from unittest.mock import MagicMock
+import httpcats
+import os
 
 
 class TestRemoteBot(object):
@@ -11,15 +12,24 @@ class TestRemoteBot(object):
         assert 'Usage' in testbot.pop_message()
 
     def test_http_valid(self, testbot):
+        helper_mock = MagicMock(return_value=True)
+        testbot.inject_mocks('HttpCats', {'has_cat': helper_mock})
+
         testbot.push_message('!http 400')
         assert 'https://http.cat/400' in testbot.pop_message()
 
     def test_http_invalid(self, testbot):
+        helper_mock = MagicMock(return_value=False)
+        testbot.inject_mocks('HttpCats', {'has_cat': helper_mock})
+
         for code in ['555', 'abc', '1']:
             testbot.push_message('!http {0}'.format(code))
             assert 'Not a valid HTTP status code' in testbot.pop_message()
 
     def test_http_regex(self, testbot):
+        helper_mock = MagicMock(return_value=True)
+        testbot.inject_mocks('HttpCats', {'has_cat': helper_mock})
+
         for message in ['http200', 'http 200', 'http  2001']:
             testbot.push_message(message)
             assert 'https://http.cat/200' in testbot.pop_message()


### PR DESCRIPTION
This will prevent calls to the http.cat API while testing. This is the best practice [recommended](https://errbot.readthedocs.io/en/latest/user_guide/plugin_development/testing.html) by the errbot documentation.